### PR TITLE
修复同步流程缩进问题

### DIFF
--- a/logic.py
+++ b/logic.py
@@ -300,31 +300,46 @@ class StockSyncProcessor:
             self._update_progress(f"已替换物料编码: {old_code} -> {new_code}")
 
     def _synchronize_by_flow(self):
-        """按照指定流程同步批次号和辅助属性"""
+        """按照给定流程同步批次号和辅助属性"""
         self._update_progress("正在同步批次和辅助属性...")
 
         mappings = list(self.material_mapping.items())
         total = len(mappings)
         n = 1
+
         for old_code, new_code in mappings:
-            self._update_progress(f"处理料号 {n}/{total}: {old_code} -> {new_code}")
+            self._update_progress(
+                f"处理料号 {n}/{total}: {old_code} -> {new_code}")
+
+            # 步骤2：获取涉及的仓库
             warehouses = self.sales_df[self.sales_df['DZ'] == new_code]['GJ'].dropna().unique()
 
             for warehouse in warehouses:
-                sales_idx = self.sales_df[(self.sales_df['DZ'] == new_code) & (self.sales_df['GJ'] == warehouse)].index
-                if len(sales_idx) == 0:
+                # 步骤2：筛选该仓库的销售记录
+                sales_rows = self.sales_df[(self.sales_df['DZ'] == new_code) &
+                                           (self.sales_df['GJ'] == warehouse)]
+                if sales_rows.empty:
                     continue
 
-                stock_subset = self.stock_df[(self.stock_df['A'] == new_code) & (self.stock_df['G'] == warehouse)]
+                # 步骤3：在库存表中筛选相同仓库
+                stock_rows = self.stock_df[self.stock_df['G'] == warehouse]
+
+                # 步骤5：筛选库存表中物料编码等于新料号的记录
+                stock_subset = stock_rows[stock_rows['A'] == new_code]
                 if stock_subset.empty:
-                    self._update_progress(f"警告: 库存表中没有找到仓库 {warehouse} 的料号 {new_code}")
+                    self._update_progress(
+                        f"警告: 库存表中没有找到仓库 {warehouse} 的料号 {new_code}")
                     continue
 
+                # 步骤6：按可用库存降序排序，取最大值行
                 stock_row = stock_subset.sort_values(by='K', ascending=False).iloc[0]
                 batch = stock_row['H']
                 aux_e = stock_row['E']
                 aux_f = stock_row['F']
 
+                sales_idx = sales_rows.index
+
+                # 步骤7-10：更新销售出库单相应字段
                 self.sales_df.loc[sales_idx, 'FF'] = batch
                 self.sales_df.loc[sales_idx, 'FG'] = batch
                 self.sales_df.loc[sales_idx, 'EC'] = aux_e


### PR DESCRIPTION
## Summary
- 重写 `_synchronize_by_flow`，确保按流程筛选仓库和物料并同步批次号

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f388d9a8083239fc9dfd6a76b0d03